### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,4 @@ jobs:
     with:
       version: ${{ inputs.version }}
       action-name: 'Visual Studio Marketplace Publisher'
-      action-slug: 'visual-studio-marketplace-publisher'
-      action-description:
-        'Publish your Visual Studio extensions to the marketplace with ease!'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`action-slug`, `action-description`) from publish workflow that are no longer used by the reusable gha-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly